### PR TITLE
Add Pushall Command

### DIFF
--- a/BambulabLedController.ino
+++ b/BambulabLedController.ino
@@ -26,6 +26,8 @@ bool hasHMSerror = false;
 bool ledstate = false;
 unsigned long finishstartms;
 unsigned long lastmqttconnectionattempt;
+bool needsPushAllFlag = false;
+unsigned long pushAllRequested = 0UL;
 
 ESP8266WebServer server(80);
 IPAddress apIP(192, 168, 1, 1);
@@ -110,6 +112,17 @@ void handleSetTemperature() {
     mqttClient.publish(mqttTopic, message.c_str());
   }
   return server.send(200, "text/plain", "Ok");
+}
+
+void handlePushAll() {
+  char mqttTopic[50];
+  strcpy(mqttTopic, "device/");
+  strcat(mqttTopic, PrinterID);
+  strcat(mqttTopic, "/request");
+  String message = "{\"pushing\":{\"sequence_id\":\"0\",\"command\":\"start\"}}";
+  mqttClient.publish(mqttTopic, message.c_str());
+  message = "{\"pushing\":{\"sequence_id\":\"1\",\"command\":\"pushall\"}}";
+  mqttClient.publish(mqttTopic, message.c_str());
 }
 
 void handleSetupRoot() { //Function to handle the setuppage
@@ -319,6 +332,8 @@ if (WiFi.status() != WL_CONNECTED){
         Serial.println("Topic: ");
         Serial.println(mqttTopic);
         mqttClient.subscribe(mqttTopic);
+        needsPushAllFlag = true;
+        pushAllRequested = millis();
         lastmqttconnectionattempt;
       } else {
         setPins(0,0,0,0,0); //Turn off led printer is offline and or the given information is wrong
@@ -326,9 +341,17 @@ if (WiFi.status() != WL_CONNECTED){
         Serial.print(mqttClient.state());
         Serial.println(" try again in 10 seconds");
         lastmqttconnectionattempt = millis();
+        needsPushAllFlag = false;
       }
     }
   }
+  
+  if(needsPushAllFlag && mqttClient.connected() && millis() - pushAllRequested >= 10000) {
+    handlePushAll();
+    needsPushAllFlag = false;
+    pushAllRequested = 0UL;
+  }
+  
   //Serial.printf("Free heap: %u\n", ESP.getFreeHeap());
   mqttClient.loop();
 }


### PR DESCRIPTION
Added pushall command to fire one time after successful connection to MQTT

This should allow the BLLC to retrieve a full mqtt message on first connection to the MQTT broker on the printer, so it can initialize various things as needed and wait for status updates to come in over time.

Note: I do not have a d1-mini or BLLC handy, so this should be compiled, flashed and tested before merging. I can only verify the commands are correct, logic seems okay, and that it compiled when I tried locally.